### PR TITLE
It fix a value of main property in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-pixi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12388,6 +12388,12 @@
         "vue-hot-reload-api": "^2.3.0",
         "vue-style-loader": "^4.1.0"
       }
+    },
+    "vue-router": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.0.6.tgz",
+      "integrity": "sha512-Ox0ciFLswtSGRTHYhGvx2L44sVbTPNS+uD2kRISuo8B39Y79rOo0Kw0hzupTmiVtftQYCZl87mwldhh2L9Aquw==",
+      "dev": true
     },
     "vue-style-loader": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "vue-cli-service lint",
     "publish": "npx np"
   },
-  "main": "./dist/vue-pixi.common.js",
+  "main": "./src/index.js",
   "dependencies": {
     "pixi.js": "^4.8.1",
     "vue": "^2.5.17"


### PR DESCRIPTION
Currently your vue-fixi can be used as <import VuePixi from 'vue-pixi / src / index.js'> after npm installing.
I think <import VuePixi from 'vue-pixi'> is right like your documentation. 
Of course, your package is not version 1 yet, I wanna be helpful. Thank you.